### PR TITLE
Drop None instances from metadata in TSN_dataset

### DIFF
--- a/src/datasets/tsn_dataset.py
+++ b/src/datasets/tsn_dataset.py
@@ -127,6 +127,8 @@ class TsnDataset(torch.utils.data.Dataset):
         def is_scalar(v: Any):
             if isinstance(v, (tuple, list)):
                 return False
+            if v is None:
+                return False 
             return True
 
         return {k: v for k, v in metadata.items() if is_scalar(v)}

--- a/src/systems.py
+++ b/src/systems.py
@@ -102,7 +102,7 @@ class EpicActionRecogintionDataModule(pl.LightningDataModule):
             num_segments=frame_count,
             segment_length=self.cfg.data.segment_length,
             transform=self.train_transform,
-            drop_non_scalar_metadata=True,
+            drop_problematic_metadata=True,
         )
         if self.cfg.data.get("train_on_val", False):
             LOG.info("Training on training set + validation set")
@@ -114,7 +114,7 @@ class EpicActionRecogintionDataModule(pl.LightningDataModule):
                         num_segments=frame_count,
                         segment_length=self.cfg.data.segment_length,
                         transform=self.train_transform,
-                        drop_non_scalar_metadata=True,
+                        drop_problematic_metadata=True,
                     ),
                 ]
             )
@@ -137,7 +137,7 @@ class EpicActionRecogintionDataModule(pl.LightningDataModule):
             segment_length=self.cfg.data.segment_length,
             transform=self.test_transform,
             test_mode=True,
-            drop_non_scalar_metadata=True,
+            drop_problematic_metadata=True,
         )
         LOG.info(f"Validation dataset size: {len(dataset)}")
         return DataLoader(
@@ -157,7 +157,7 @@ class EpicActionRecogintionDataModule(pl.LightningDataModule):
             segment_length=self.cfg.data.segment_length,
             transform=self.test_transform,
             test_mode=True,
-            drop_non_scalar_metadata=True,
+            drop_problematic_metadata=True,
         )
         LOG.info(f"Test dataset size: {len(dataset)}")
         return DataLoader(


### PR DESCRIPTION
Dataloader fails with the below error if some of the metadata values are None.
```TypeError: default_collate: batch must contain tensors, numpy arrays, numbers, dicts or lists; found <class 'NoneType'>```

Fixed by dropping all key-value pairs of the metadata with values that are None in the tsn_dataset class.